### PR TITLE
[bug]: #103 fix bug about NICK error

### DIFF
--- a/include/User.hpp
+++ b/include/User.hpp
@@ -23,6 +23,7 @@ class User {
   public:
 	enum AuthFlags { NONE_AUTH, PASS_AUTH, NICK_AUTH, USER_AUTH, ALL_AUTH };
 	enum UserMode {
+		none = 0,
 		a = 1 << 1,
 		i = 1 << 2,
 		w = 1 << 3,

--- a/src/Command_NICK.cpp
+++ b/src/Command_NICK.cpp
@@ -70,7 +70,6 @@ void Command::NICK(User &user, std::vector<std::string> &arg) {
 	} else {
 		server_.nicknameInsertLog(arg.at(0));
 		user.setNickname(arg.at(0));
-		user.setAuthFlags(User::NICK_AUTH);
 		if (user.getAuthFlags() == User::USER_AUTH) {
 			user.setAuthFlags(User::ALL_AUTH);
 		} else {

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -1,8 +1,9 @@
 #include "User.hpp"
 
-User::User(const int fd) : fd_(fd), auth_flag_(NONE_AUTH), nick_name_("") {
+User::User(const int fd)
+	: fd_(fd), mode_(none), auth_flag_(NONE_AUTH), nick_name_(""),
+	  user_name_(""), real_name_("") {
 	// std::cout << "User fd_: " << this->fd_ << " ,is_auth_: " << std::endl;
-	(void)nick_name_;
 }
 
 int User::getFd() const { return (this->fd_); }


### PR DESCRIPTION
[body]
- Userクラスのmode_が初期化されておらず、NICKコマンドが常にエラーになっていました
- そのためUserクラスのUserModeのenumにnone = 0を追加し、コンストラクタでmode_をnoneで初期化するようにしました

[notes]

close #103 