### PR TITLE
96 feat create MODE command, 105 refactor change valid AuthFlag int JOIN command

### DIFF
--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -5,8 +5,8 @@
 #include "Server.hpp"
 #include "User.hpp"
 
+#include <algorithm>
 #include <map>
-#include <string>
 
 class User;
 
@@ -42,6 +42,7 @@ class Channel {
 	const std::string &getPass() const;
 	const std::vector<int> &getChannelOperators() const;
 	size_t getJoinedUserCount() const;
+	const std::string &getCreatedUser() const;
 	void setUser(const User &user);
 	void setChannelOperators(const int user_fd);
 	enum ChannelMode getMode() const;
@@ -50,12 +51,14 @@ class Channel {
 	void removeUser(const int fd);
 	void printJoinedUser() const;
 	void printChannelOperators() const;
+	bool isChannelOperator(const User &user) const;
 
   private:
 	std::string ch_name_;
 	std::string ch_pass_;
 	std::map<int, User> ch_users_;
 	enum ChannelMode mode_;
+	std::string created_user_;
 	std::vector<int> ch_operators_;
 };
 

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -11,7 +11,9 @@
 class User;
 
 class Channel {
+  public:
 	enum ChannelMode {
+		none = 0,
 		O = 1 << 1,
 		o = 1 << 2,
 		v = 1 << 3,
@@ -38,19 +40,23 @@ class Channel {
 	Channel(const std::string &name, const std::string &pass, const User &user);
 	const std::string &getName() const;
 	const std::string &getPass() const;
+	const std::vector<int> &getChannelOperators() const;
 	size_t getJoinedUserCount() const;
 	void setUser(const User &user);
+	void setChannelOperators(const int user_fd);
 	enum ChannelMode getMode() const;
 	void setMode(const enum ChannelMode mode);
 	bool hasMode(const enum ChannelMode mode) const;
 	void removeUser(const int fd);
 	void printJoinedUser() const;
+	void printChannelOperators() const;
 
   private:
 	std::string ch_name_;
 	std::string ch_pass_;
 	std::map<int, User> ch_users_;
 	enum ChannelMode mode_;
+	std::vector<int> ch_operators_;
 };
 
 #endif

--- a/include/Command.hpp
+++ b/include/Command.hpp
@@ -25,6 +25,8 @@ class Command {
 	void handleCommand(User &user, std::string &message);
 
   private:
+	enum ModeAction { setMode, unsetMode, queryMode };
+
 	Server &server_;
 	Error error_;
 	std::string command_name_;
@@ -33,6 +35,9 @@ class Command {
 	typedef void (Command::*CommandFunction)(User &,
 											 std::vector<std::string> &);
 	std::map<std::string, CommandFunction> commands_map_;
+	typedef void (Command::*ModeFunction)(const ModeAction, User &,
+										  const Channel &);
+	std::map<char, ModeFunction> mode_map_;
 	std::set<std::string> nickname_log_;
 
   private:
@@ -79,7 +84,16 @@ class Command {
 	std::string substrRealName(size_t i) const;
 
 	void TEST(User &user, std::vector<std::string> &arg);
-	// void MOD(User &user, std::vector<std::string> &arg);
+
+	// MODE
+	void MODE(User &user, std::vector<std::string> &arg);
+	void handleChannelMode(User &user, std::vector<std::string> &arg,
+						   const Channel &ch_name);
+	ModeAction checkModeAction(const std::string &mode_str) const;
+	bool checkModeType(const char c) const;
+	void handleChannelOriginOperator(const ModeAction mode_action, User &user,
+									 const Channel &ch); // mode "O"
+	bool checkInvalidSignsCount(const std::string &mode_str);
 };
 
 #endif

--- a/include/Error.hpp
+++ b/include/Error.hpp
@@ -25,6 +25,11 @@ class Error {
 	std::string ERR_NOTSETPASS() const;
 	std::string ERR_NOSUCHCHANNEL(const std::string &ch_name) const;
 	std::string ERR_BADCHANNELKEY(const std::string &ch_name) const;
+	std::string ERR_CHANOPRIVSNEEDED(const std::string &ch_name) const;
+	std::string ERR_UNKNOWNMODE(const std::string &c,
+								const std::string &ch_name) const;
+	std::string ERR_NOPRIVILEGES() const;
+	std::string ERR_UMODEUNKNOWNFLAG(const std::string &mode_flag) const;
 };
 
 #endif

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -29,10 +29,18 @@ const std::string &Channel::getName() const { return (this->ch_name_); }
 
 const std::string &Channel::getPass() const { return (this->ch_pass_); }
 
+const std::vector<int> &Channel::getChannelOperators() const {
+	return this->ch_operators_;
+}
+
 size_t Channel::getJoinedUserCount() const { return (this->ch_users_.size()); }
 
 void Channel::setUser(const User &user) {
 	this->ch_users_.insert(std::make_pair(user.getFd(), user));
+}
+
+void Channel::setChannelOperators(const int user_fd) {
+	this->ch_operators_.push_back(user_fd);
 }
 
 enum Channel::ChannelMode Channel::getMode() const { return this->mode_; }
@@ -50,6 +58,14 @@ void Channel::printJoinedUser() const {
 	for (std::map<int, User>::const_iterator it = ch_users_.begin();
 		 it != ch_users_.end(); ++it) {
 		std::cout << "client[" << it->first << "], ";
+	}
+	std::cout << std::endl;
+}
+
+void Channel::printChannelOperators() const {
+	std::cout << this->ch_name_ << " channel operators: ";
+	for (size_t i = 0; i < this->ch_operators_.size(); ++i) {
+		std::cout << "client[" << ch_operators_[i] << "], ";
 	}
 	std::cout << std::endl;
 }

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -1,24 +1,25 @@
 #include "Channel.hpp"
 
-Channel::Channel() : ch_name_(""), ch_pass_("") {
+Channel::Channel() : ch_name_(""), ch_pass_(""), created_user_("") {
 	// std::cout << "Channel Constructor, ch_name_: " << this->ch_name_ <<
 	// std::endl;
 }
 
-Channel::Channel(const std::string &ch_name) : ch_name_(ch_name), ch_pass_("") {
+Channel::Channel(const std::string &ch_name)
+	: ch_name_(ch_name), ch_pass_(""), created_user_("") {
 	// std::cout << "Channel Constructor, ch_name_: " << this->ch_name_ <<
 	// std::endl;
 }
 
 Channel::Channel(const std::string &name, const std::string &pass)
-	: ch_name_(name), ch_pass_(pass) {
+	: ch_name_(name), ch_pass_(pass), created_user_("") {
 	// std::cout << "Channel Constructor, ch_name_: " << this->ch_name_ <<
 	// "ch_pass_: " << this->ch_pass_ << std::endl;
 }
 
 Channel::Channel(const std::string &name, const std::string &pass,
 				 const User &user)
-	: ch_name_(name), ch_pass_(pass) {
+	: ch_name_(name), ch_pass_(pass), created_user_(user.getNickName()) {
 	setUser(user);
 	// std::cout << "Channel Constructor with user, ch_name_: " <<
 	// this->ch_name_
@@ -34,6 +35,10 @@ const std::vector<int> &Channel::getChannelOperators() const {
 }
 
 size_t Channel::getJoinedUserCount() const { return (this->ch_users_.size()); }
+
+const std::string &Channel::getCreatedUser() const {
+	return (this->created_user_);
+}
 
 void Channel::setUser(const User &user) {
 	this->ch_users_.insert(std::make_pair(user.getFd(), user));
@@ -79,4 +84,9 @@ void Channel::removeUser(const int fd) {
 		std::cerr << "cannot remove client[" << fd << "]" << std::endl;
 	}
 	printJoinedUser();
+}
+
+bool Channel::isChannelOperator(const User &user) const {
+	return std::find(this->ch_operators_.begin(), this->ch_operators_.end(),
+					 user.getFd()) != ch_operators_.end();
 }

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -7,6 +7,8 @@ Command::Command(Server &server) : server_(server) {
 	this->commands_map_["JOIN"] = &Command::JOIN;
 	this->commands_map_["NICK"] = &Command::NICK;
 	this->commands_map_["USER"] = &Command::USER;
+	this->commands_map_["MODE"] = &Command::MODE;
+	this->mode_map_['O'] = &Command::handleChannelOriginOperator;
 	// std::cout << "server pass is" << server_.getPass() << std::endl;
 }
 

--- a/src/Command_JOIN.cpp
+++ b/src/Command_JOIN.cpp
@@ -83,12 +83,15 @@ void Command::joinChannel(const std::string &ch_name, const std::string &ch_key,
 void Command::createChannel(const std::string &ch_name,
 							const std::string &ch_key, User &user) {
 	Channel new_ch(ch_name, ch_key, user);
+	new_ch.setMode(Channel::O);
+	new_ch.setChannelOperators(user.getFd());
 	this->server_.setChannel(new_ch.getName(), new_ch);
 	user.setChannel(new_ch);
 	std::cout << "finish JOIN command" << std::endl;
 	user.printJoinChannel();
 	const Channel ch = this->server_.getChannel(ch_name);
 	ch.printJoinedUser();
+	ch.printChannelOperators();
 	this->server_.sendMsgToClient(user.getFd(), "SUCCESS: JOIN Command");
 }
 

--- a/src/Command_JOIN.cpp
+++ b/src/Command_JOIN.cpp
@@ -132,8 +132,7 @@ void Command::exitAllChannels(User &user) {
 
 void Command::JOIN(User &user, std::vector<std::string> &arg) {
 	std::cout << "start JOIN command" << std::endl;
-	// if (user.getAuthFlags() != User::ALL_AUTH) {
-	if (user.getAuthFlags() != User::PASS_AUTH) {
+	if (user.getAuthFlags() != User::ALL_AUTH) {
 		std::cerr << "client cannot authenticate" << std::endl;
 		server_.sendMsgToClient(user.getFd(), "client cannot authenticate");
 		return;

--- a/src/Command_MODE.cpp
+++ b/src/Command_MODE.cpp
@@ -1,0 +1,106 @@
+#include "Command.hpp"
+
+void Command::MODE(User &user, std::vector<std::string> &arg) {
+	std::cout << "start MODE command" << std::endl;
+	if (user.getAuthFlags() != User::ALL_AUTH) {
+		std::cerr << "client cannot authenticate" << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  "client cannot authenticate");
+		return;
+	} else if (arg.empty() || arg.size() == 1) {
+		std::cerr << error_.ERR_NEEDMOREPARAMS("MODE") << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  error_.ERR_NEEDMOREPARAMS("MODE"));
+		return;
+	}
+	if (this->server_.hasChannelName(arg.at(0))) {
+		handleChannelMode(user, arg, this->server_.getChannel(arg.at(0)));
+	} else {
+		// handleUserMode(user, arg);
+		std::cerr << error_.ERR_NOSUCHCHANNEL("MODE") << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  error_.ERR_NOSUCHCHANNEL("MODE"));
+		return;
+	}
+}
+
+Command::ModeAction
+Command::checkModeAction(const std::string &mode_str) const {
+	if (mode_str[0] == '+') {
+		return Command::setMode;
+	} else if (mode_str[0] == '-') {
+		return Command::unsetMode;
+	} else {
+		return Command::queryMode;
+	}
+}
+
+void Command::handleChannelOriginOperator(const ModeAction mode_action,
+										  User &user, const Channel &ch) {
+	if (mode_action == Command::unsetMode || mode_action == Command::setMode) {
+		std::cerr << error_.ERR_NOPRIVILEGES() << std::endl;
+		this->server_.sendMsgToClient(user.getFd(), error_.ERR_NOPRIVILEGES());
+		return;
+	} else if (this->arg_.size() > 3) {
+		std::cerr << "O: mode parameters are not required" << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  "O: mode parameters are not required");
+		return;
+	}
+	std::cout << ch.getName() << " " << ch.getCreatedUser() << std::endl;
+	this->server_.sendMsgToClient(user.getFd(),
+								  ch.getName() + " " + ch.getCreatedUser());
+}
+
+bool Command::checkInvalidSignsCount(const std::string &mode_str) {
+	int count = 0;
+	for (size_t i = 0; i < mode_str.size(); ++i) {
+		if (mode_str[i] == '+' || mode_str[i] == '-') {
+			count++;
+		}
+		if (count > 1) {
+			return false;
+		}
+	}
+	return true;
+}
+
+void Command::handleChannelMode(User &user, std::vector<std::string> &arg,
+								const Channel &ch) {
+	size_t i = 0;
+	std::string mode_str = arg.at(1);
+	if (!checkInvalidSignsCount(mode_str)) {
+		std::cerr << error_.ERR_UMODEUNKNOWNFLAG(mode_str) << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  error_.ERR_UMODEUNKNOWNFLAG(mode_str));
+		return;
+	}
+	ModeAction mode_action = checkModeAction(mode_str);
+	if ((mode_action == Command::setMode ||
+		 mode_action == Command::unsetMode) &&
+		!ch.isChannelOperator(user)) {
+		std::cerr << error_.ERR_CHANOPRIVSNEEDED(ch.getName()) << std::endl;
+		this->server_.sendMsgToClient(
+			user.getFd(), error_.ERR_CHANOPRIVSNEEDED(ch.getName()));
+		return;
+	}
+	if (mode_action == Command::setMode || mode_action == Command::unsetMode) {
+		i++;
+	}
+	std::cout << "start handleChannelMode: " << mode_action << std::endl;
+	for (; i < mode_str.size(); ++i) {
+		char mode_type = mode_str[i];
+		ModeFunction mode_func = this->mode_map_[mode_type];
+		if (!mode_func) {
+			std::cerr << error_.ERR_UNKNOWNMODE(std::string(1, mode_type),
+												ch.getName())
+					  << std::endl;
+			this->server_.sendMsgToClient(
+				user.getFd(), error_.ERR_UNKNOWNMODE(std::string(1, mode_type),
+													 ch.getName()));
+			continue;
+		}
+		std::cout << "mode_type: " << mode_type << std::endl;
+		(this->*mode_func)(mode_action, user, ch);
+	}
+}

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -37,3 +37,20 @@ std::string Error::ERR_NOSUCHCHANNEL(const std::string &ch_name) const {
 std::string Error::ERR_BADCHANNELKEY(const std::string &ch_name) const {
 	return ch_name + ":Cannot join channel (+k)";
 }
+
+std::string Error::ERR_CHANOPRIVSNEEDED(const std::string &ch_name) const {
+	return ch_name + ":You're not channel operator";
+}
+
+std::string Error::ERR_UNKNOWNMODE(const std::string &c,
+								   const std::string &ch_name) const {
+	return c + ":is unknown mode char to me for " + ch_name;
+}
+
+std::string Error::ERR_NOPRIVILEGES() const {
+	return ":Permission Denied- You're not an IRC operator";
+}
+
+std::string Error::ERR_UMODEUNKNOWNFLAG(const std::string &mode_flag) const {
+	return mode_flag + ":Unknown MODE flag";
+}


### PR DESCRIPTION
- MODE コマンドを新しく作成しました。チャンネルモードのみでユーザモードはまだ実装していません
- Oモードを実装しました。Oモードはチャンネル作成者が自動的にそのチャンネルのオペレーターになります
 - チャンネル作成者をstd::vector<std::string> created_userで保持しています
 - 本来はチャンネル名が'!'から始まるチャンネルのみでしか適用されません(まだチャンネル名の違いによる挙動を変更していないので、今回のプルリクでは全てのチャンネルでチャンネル作成者がオペレーターになるように設定しています)
 - https://solareenlo.com/rfc2811/channel-modes/channel-creator-status.html
- JOINコマンドの最初のAuthFlagsの判定をPASS_AUTHからALL_AUTHに変更しました