### PR TITLE
108 feat mode o (先にpull109をマージしてからこのプルリクをレビューして下さい)

### DIFF
--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -40,18 +40,20 @@ class Channel {
 	Channel(const std::string &name, const std::string &pass, const User &user);
 	const std::string &getName() const;
 	const std::string &getPass() const;
-	const std::vector<int> &getChannelOperators() const;
+	const std::vector<std::string> &getChannelOperators() const;
 	size_t getJoinedUserCount() const;
 	const std::string &getCreatedUser() const;
 	void setUser(const User &user);
-	void setChannelOperators(const int user_fd);
+	void setChannelOperator(const std::string &user_nickname);
+	void removeChannelOperator(const std::string &user_nickname);
 	enum ChannelMode getMode() const;
 	void setMode(const enum ChannelMode mode);
 	bool hasMode(const enum ChannelMode mode) const;
 	void removeUser(const int fd);
 	void printJoinedUser() const;
 	void printChannelOperators() const;
-	bool isChannelOperator(const User &user) const;
+	bool isChannelOperator(const std::string &nick_name) const;
+	bool isChannelUser(const std::string &nick_name) const;
 
   private:
 	std::string ch_name_;
@@ -59,7 +61,7 @@ class Channel {
 	std::map<int, User> ch_users_;
 	enum ChannelMode mode_;
 	std::string created_user_;
-	std::vector<int> ch_operators_;
+	std::vector<std::string> ch_operators_;
 };
 
 #endif

--- a/include/Command.hpp
+++ b/include/Command.hpp
@@ -91,9 +91,16 @@ class Command {
 						   const Channel &ch_name);
 	ModeAction checkModeAction(const std::string &mode_str) const;
 	bool checkModeType(const char c) const;
+	bool checkInvalidSignsCount(const std::string &mode_str);
+	void joinStrFromVector(std::string &join_str,
+						   const std::vector<std::string> &vec,
+						   const std::string delimiter);
 	void handleChannelOriginOperator(const ModeAction mode_action, User &user,
 									 const Channel &ch); // mode "O"
-	bool checkInvalidSignsCount(const std::string &mode_str);
+	void handleChannelOperator(const ModeAction mode_action, User &user,
+							   const Channel &ch); // mode "o"
+	void setOrUnsetChannelOperator(const size_t i, const ModeAction mode_action,
+								   User &user, const Channel &ch);
 };
 
 #endif

--- a/include/Error.hpp
+++ b/include/Error.hpp
@@ -30,6 +30,8 @@ class Error {
 								const std::string &ch_name) const;
 	std::string ERR_NOPRIVILEGES() const;
 	std::string ERR_UMODEUNKNOWNFLAG(const std::string &mode_flag) const;
+	std::string ERR_USERNOTINCHANNEL(const std::string &nick_name,
+									 const std::string &ch_name) const;
 };
 
 #endif

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -30,7 +30,7 @@ const std::string &Channel::getName() const { return (this->ch_name_); }
 
 const std::string &Channel::getPass() const { return (this->ch_pass_); }
 
-const std::vector<int> &Channel::getChannelOperators() const {
+const std::vector<std::string> &Channel::getChannelOperators() const {
 	return this->ch_operators_;
 }
 
@@ -44,8 +44,18 @@ void Channel::setUser(const User &user) {
 	this->ch_users_.insert(std::make_pair(user.getFd(), user));
 }
 
-void Channel::setChannelOperators(const int user_fd) {
-	this->ch_operators_.push_back(user_fd);
+void Channel::setChannelOperator(const std::string &user_nickname) {
+	this->ch_operators_.push_back(user_nickname);
+}
+
+void Channel::removeChannelOperator(const std::string &user_nickname) {
+	for (std::vector<std::string>::iterator it = this->ch_operators_.begin();
+		 it != this->ch_operators_.end(); ++it) {
+		if (*it == user_nickname) {
+			it = this->ch_operators_.erase(it);
+			return;
+		}
+	}
 }
 
 enum Channel::ChannelMode Channel::getMode() const { return this->mode_; }
@@ -86,7 +96,17 @@ void Channel::removeUser(const int fd) {
 	printJoinedUser();
 }
 
-bool Channel::isChannelOperator(const User &user) const {
+bool Channel::isChannelOperator(const std::string &nick_name) const {
 	return std::find(this->ch_operators_.begin(), this->ch_operators_.end(),
-					 user.getFd()) != ch_operators_.end();
+					 nick_name) != ch_operators_.end();
+}
+
+bool Channel::isChannelUser(const std::string &nick_name) const {
+	for (std::map<int, User>::const_iterator it = ch_users_.begin();
+		 it != ch_users_.end(); ++it) {
+		if (nick_name == it->second.getNickName()) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -9,6 +9,7 @@ Command::Command(Server &server) : server_(server) {
 	this->commands_map_["USER"] = &Command::USER;
 	this->commands_map_["MODE"] = &Command::MODE;
 	this->mode_map_['O'] = &Command::handleChannelOriginOperator;
+	this->mode_map_['o'] = &Command::handleChannelOperator;
 	// std::cout << "server pass is" << server_.getPass() << std::endl;
 }
 
@@ -54,23 +55,3 @@ void Command::TEST(User &user, std::vector<std::string> &arg) {
 	this->server_.printChannelName();
 	server_.sendMsgToClient(user.getFd(), "Command => printTest: Hello world!");
 }
-
-// void Command::MOD(User &user, std::vector<std::string> &arg) {
-//	(void)arg;
-//	user.setMode(User::s);
-//	std::cout << user.getMode() << std::endl;
-//	std::cout << user.hasMode(User::s) << std::endl;
-//	std::cout << "check w" << std::endl;
-//	std::cout << user.hasMode(User::w) << std::endl;
-//	std::cout << "+w" << std::endl;
-//	user.setMode(User::w);
-//	std::cout << "check w" << std::endl;
-//	std::cout << user.hasMode(User::w) << std::endl;
-//	std::cout << "check o" << std::endl;
-//	std::cout << user.hasMode(User::o) << std::endl;
-//	std::cout << "check a" << std::endl;
-//	std::cout << user.hasMode(User::a) << std::endl;
-//	std::cout << "+a" << std::endl;
-//	user.setMode(User::a);
-//	std::cout << user.hasMode(User::a) << std::endl;
-// }

--- a/src/Command_JOIN.cpp
+++ b/src/Command_JOIN.cpp
@@ -84,7 +84,7 @@ void Command::createChannel(const std::string &ch_name,
 							const std::string &ch_key, User &user) {
 	Channel new_ch(ch_name, ch_key, user);
 	new_ch.setMode(Channel::O);
-	new_ch.setChannelOperators(user.getFd());
+	new_ch.setChannelOperator(user.getNickName());
 	this->server_.setChannel(new_ch.getName(), new_ch);
 	user.setChannel(new_ch);
 	std::cout << "finish JOIN command" << std::endl;
@@ -125,6 +125,10 @@ void Command::exitAllChannels(User &user) {
 		 it != joined_ch.end(); ++it) {
 		const std::string ch_name = *it;
 		const Channel &left_ch_const = this->server_.getChannel(ch_name);
+		if (left_ch_const.isChannelOperator(user.getNickName())) {
+			const_cast<Channel &>(left_ch_const)
+				.removeChannelOperator(user.getNickName());
+		}
 		const_cast<Channel &>(left_ch_const).removeUser(user.getFd());
 		if (left_ch_const.getJoinedUserCount() == 0) {
 			this->server_.removeChannel(left_ch_const.getName());

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -54,3 +54,8 @@ std::string Error::ERR_NOPRIVILEGES() const {
 std::string Error::ERR_UMODEUNKNOWNFLAG(const std::string &mode_flag) const {
 	return mode_flag + ":Unknown MODE flag";
 }
+
+std::string Error::ERR_USERNOTINCHANNEL(const std::string &nick_name,
+										const std::string &ch_name) const {
+	return nick_name + " " + ch_name + " They aren't on that channel";
+}


### PR DESCRIPTION
- チャンネルモードoを実装しました
- チャンネルオペレーターを保持するChannelクラスのch_operators_をstd::vector<int>からstd::vector<std::string>とニックネームで保持するように変更しました
- チャンネルオペレーターはチャンネルに参加しているユーザーを"MODE #ch1 +o user1"のようにチャンネルオペレーターにすることができます
- "MODE #ch1 +o user1 user2"のように複数のユーザーをチャンネルオペレーターにすることも可能です
- "MODE #ch1 o"と+,-なしで送信すると指定したチャンネルのチャンネルオペレーターが一覧表示されます
- "MODE #ch1 ++o user1","MODE #ch1 --o user1","MODE #ch1 +-o user1"のように+,-が2つ以上あるとエラーにするようにしています
- "MODE #ch1 -o created_user"のように、チャンネル作成者を別のチャンネルオペレーターが削除しようとしてもできないようにしています
