### PR TITLE
[fix]: #112 change to pointer

### DIFF
--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -52,6 +52,8 @@ class Channel {
 	bool hasMode(const enum ChannelMode mode) const;
 	void removeUser(const int fd);
 	void printJoinedUser() const;
+	std::map<int, User *>::const_iterator getMapBeginIterator() const;
+	std::map<int, User *>::const_iterator getMapEndIterator() const;
 	void printChannelOperators() const;
 	bool isChannelOperator(const int user_fd) const;
 	bool isChannelUser(const int user_fd) const;

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -49,7 +49,7 @@ class Channel {
   private:
 	std::string ch_name_;
 	std::string ch_pass_;
-	std::map<int, User> ch_users_;
+	std::map<int, User *> ch_users_;
 	enum ChannelMode mode_;
 };
 

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -40,28 +40,29 @@ class Channel {
 	Channel(const std::string &name, const std::string &pass, const User &user);
 	const std::string &getName() const;
 	const std::string &getPass() const;
-	const std::vector<std::string> &getChannelOperators() const;
+	const std::vector<int> &getChannelOperators() const;
 	size_t getJoinedUserCount() const;
+	const std::vector<std::string> getChannelOperatorsNickName() const;
 	const std::string &getCreatedUser() const;
 	void setUser(const User &user);
-	void setChannelOperator(const std::string &user_nickname);
-	void removeChannelOperator(const std::string &user_nickname);
+	void setChannelOperator(const int user_fd);
+	void removeChannelOperator(const int user_fd);
 	enum ChannelMode getMode() const;
 	void setMode(const enum ChannelMode mode);
 	bool hasMode(const enum ChannelMode mode) const;
 	void removeUser(const int fd);
 	void printJoinedUser() const;
 	void printChannelOperators() const;
-	bool isChannelOperator(const std::string &nick_name) const;
-	bool isChannelUser(const std::string &nick_name) const;
+	bool isChannelOperator(const int user_fd) const;
+	bool isChannelUser(const int user_fd) const;
 
   private:
 	std::string ch_name_;
 	std::string ch_pass_;
 	std::map<int, User *> ch_users_;
 	enum ChannelMode mode_;
-	std::string created_user_;
-	std::vector<std::string> ch_operators_;
+	int created_user_fd_;
+	std::vector<int> ch_operators_;
 };
 
 #endif

--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -5,13 +5,15 @@
 #include "Server.hpp"
 #include "User.hpp"
 
+#include <algorithm>
 #include <map>
-#include <string>
 
 class User;
 
 class Channel {
+  public:
 	enum ChannelMode {
+		none = 0,
 		O = 1 << 1,
 		o = 1 << 2,
 		v = 1 << 3,
@@ -38,19 +40,28 @@ class Channel {
 	Channel(const std::string &name, const std::string &pass, const User &user);
 	const std::string &getName() const;
 	const std::string &getPass() const;
+	const std::vector<std::string> &getChannelOperators() const;
 	size_t getJoinedUserCount() const;
+	const std::string &getCreatedUser() const;
 	void setUser(const User &user);
+	void setChannelOperator(const std::string &user_nickname);
+	void removeChannelOperator(const std::string &user_nickname);
 	enum ChannelMode getMode() const;
 	void setMode(const enum ChannelMode mode);
 	bool hasMode(const enum ChannelMode mode) const;
 	void removeUser(const int fd);
 	void printJoinedUser() const;
+	void printChannelOperators() const;
+	bool isChannelOperator(const std::string &nick_name) const;
+	bool isChannelUser(const std::string &nick_name) const;
 
   private:
 	std::string ch_name_;
 	std::string ch_pass_;
 	std::map<int, User *> ch_users_;
 	enum ChannelMode mode_;
+	std::string created_user_;
+	std::vector<std::string> ch_operators_;
 };
 
 #endif

--- a/include/Command.hpp
+++ b/include/Command.hpp
@@ -25,6 +25,8 @@ class Command {
 	void handleCommand(User &user, std::string &message);
 
   private:
+	enum ModeAction { setMode, unsetMode, queryMode };
+
 	Server &server_;
 	Error error_;
 	std::string command_name_;
@@ -33,6 +35,9 @@ class Command {
 	typedef void (Command::*CommandFunction)(User &,
 											 std::vector<std::string> &);
 	std::map<std::string, CommandFunction> commands_map_;
+	typedef void (Command::*ModeFunction)(const ModeAction, User &,
+										  const Channel &);
+	std::map<char, ModeFunction> mode_map_;
 	std::set<std::string> nickname_log_;
 
   private:
@@ -79,7 +84,23 @@ class Command {
 	std::string substrRealName(size_t i) const;
 
 	void TEST(User &user, std::vector<std::string> &arg);
-	// void MOD(User &user, std::vector<std::string> &arg);
+
+	// MODE
+	void MODE(User &user, std::vector<std::string> &arg);
+	void handleChannelMode(User &user, std::vector<std::string> &arg,
+						   const Channel &ch_name);
+	ModeAction checkModeAction(const std::string &mode_str) const;
+	bool checkModeType(const char c) const;
+	bool checkInvalidSignsCount(const std::string &mode_str);
+	void joinStrFromVector(std::string &join_str,
+						   const std::vector<std::string> &vec,
+						   const std::string delimiter);
+	void handleChannelOriginOperator(const ModeAction mode_action, User &user,
+									 const Channel &ch); // mode "O"
+	void handleChannelOperator(const ModeAction mode_action, User &user,
+							   const Channel &ch); // mode "o"
+	void setOrUnsetChannelOperator(const size_t i, const ModeAction mode_action,
+								   User &user, const Channel &ch);
 };
 
 #endif

--- a/include/Command.hpp
+++ b/include/Command.hpp
@@ -93,7 +93,7 @@ class Command {
 	bool checkModeType(const char c) const;
 	bool checkInvalidSignsCount(const std::string &mode_str);
 	void joinStrFromVector(std::string &join_str,
-						   const std::vector<std::string> &vec,
+						   const Channel &ch,
 						   const std::string delimiter);
 	void handleChannelOriginOperator(const ModeAction mode_action, User &user,
 									 const Channel &ch); // mode "O"

--- a/include/Command.hpp
+++ b/include/Command.hpp
@@ -84,6 +84,7 @@ class Command {
 	std::string substrRealName(size_t i) const;
 
 	void TEST(User &user, std::vector<std::string> &arg);
+	// void MOD(User &user, std::vector<std::string> &arg);
 
 	// MODE
 	void MODE(User &user, std::vector<std::string> &arg);
@@ -92,8 +93,7 @@ class Command {
 	ModeAction checkModeAction(const std::string &mode_str) const;
 	bool checkModeType(const char c) const;
 	bool checkInvalidSignsCount(const std::string &mode_str);
-	void joinStrFromVector(std::string &join_str,
-						   const Channel &ch,
+	void joinStrFromVector(std::string &join_str, const Channel &ch,
 						   const std::string delimiter);
 	void handleChannelOriginOperator(const ModeAction mode_action, User &user,
 									 const Channel &ch); // mode "O"

--- a/include/Error.hpp
+++ b/include/Error.hpp
@@ -32,6 +32,7 @@ class Error {
 	std::string ERR_UMODEUNKNOWNFLAG(const std::string &mode_flag) const;
 	std::string ERR_USERNOTINCHANNEL(const std::string &nick_name,
 									 const std::string &ch_name) const;
+	std::string ERR_NOSUCHNICK(const std::string &nick) const;
 };
 
 #endif

--- a/include/Error.hpp
+++ b/include/Error.hpp
@@ -25,6 +25,13 @@ class Error {
 	std::string ERR_NOTSETPASS() const;
 	std::string ERR_NOSUCHCHANNEL(const std::string &ch_name) const;
 	std::string ERR_BADCHANNELKEY(const std::string &ch_name) const;
+	std::string ERR_CHANOPRIVSNEEDED(const std::string &ch_name) const;
+	std::string ERR_UNKNOWNMODE(const std::string &c,
+								const std::string &ch_name) const;
+	std::string ERR_NOPRIVILEGES() const;
+	std::string ERR_UMODEUNKNOWNFLAG(const std::string &mode_flag) const;
+	std::string ERR_USERNOTINCHANNEL(const std::string &nick_name,
+									 const std::string &ch_name) const;
 };
 
 #endif

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -34,11 +34,13 @@ class Server {
 
 	const std::string &getPass() const;
 	const Channel &getChannel(const std::string &ch_name) const;
+	const User &getUser(const std::string &nickname) const;
 	void printChannelName() const;
 
 	void setChannel(const std::string &ch_name, const Channel &ch);
 
 	bool hasChannelName(const std::string &ch_name);
+	bool isUser(const std::string &nickname) const;
 
 	void sendMsgToClient(const int fd, const std::string &send_str);
 

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -39,21 +39,23 @@ class Server {
 
 	void setChannel(const std::string &ch_name, const Channel &ch);
 
-	bool hasChannelName(const std::string &ch_name);
+	bool hasChannelName(const std::string &ch_name) const;
 	bool isUser(const std::string &nickname) const;
 
-	void sendMsgToClient(const int fd, const std::string &send_str);
+	void sendMsgToClient(const int fd, const std::string &send_str) const;
 
 	bool nicknameExist(const std::string &nickname) const;
 	void nicknameInsertLog(std::string nickname);
 
 	void removeChannel(const std::string &ch_name);
 
+	void sendToChannelUser(std::string &ch_name, std::string &msg) const;
+
   private:
 	void checkValidArgc(const int argc) const;
 	void checkValidPort(const char *str) const;
 	void setPortAndPass(const char **argv);
-	void exit_error(const std::string &func, const std::string &err_msg);
+	void exit_error(const std::string &func, const std::string &err_msg) const;
 	std::string recvCmdFromClient(const size_t i);
 	void acceptNewClientConnect();
 	void handlPollEvents();

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -1,24 +1,25 @@
 #include "Channel.hpp"
 
-Channel::Channel() : ch_name_(""), ch_pass_("") {
+Channel::Channel() : ch_name_(""), ch_pass_(""), created_user_("") {
 	// std::cout << "Channel Constructor, ch_name_: " << this->ch_name_ <<
 	// std::endl;
 }
 
-Channel::Channel(const std::string &ch_name) : ch_name_(ch_name), ch_pass_("") {
+Channel::Channel(const std::string &ch_name)
+	: ch_name_(ch_name), ch_pass_(""), created_user_("") {
 	// std::cout << "Channel Constructor, ch_name_: " << this->ch_name_ <<
 	// std::endl;
 }
 
 Channel::Channel(const std::string &name, const std::string &pass)
-	: ch_name_(name), ch_pass_(pass) {
+	: ch_name_(name), ch_pass_(pass), created_user_("") {
 	// std::cout << "Channel Constructor, ch_name_: " << this->ch_name_ <<
 	// "ch_pass_: " << this->ch_pass_ << std::endl;
 }
 
 Channel::Channel(const std::string &name, const std::string &pass,
 				 const User &user)
-	: ch_name_(name), ch_pass_(pass) {
+	: ch_name_(name), ch_pass_(pass), created_user_(user.getNickName()) {
 	setUser(user);
 	// std::cout << "Channel Constructor with user, ch_name_: " <<
 	// this->ch_name_
@@ -29,11 +30,33 @@ const std::string &Channel::getName() const { return (this->ch_name_); }
 
 const std::string &Channel::getPass() const { return (this->ch_pass_); }
 
+const std::vector<std::string> &Channel::getChannelOperators() const {
+	return this->ch_operators_;
+}
+
 size_t Channel::getJoinedUserCount() const { return (this->ch_users_.size()); }
+
+const std::string &Channel::getCreatedUser() const {
+	return (this->created_user_);
+}
 
 void Channel::setUser(const User &user) {
 	// this->ch_users_.insert(std::make_pair(user.getFd(), &user));
 	this->ch_users_[user.getFd()] = const_cast<User *>(&user);
+}
+
+void Channel::setChannelOperator(const std::string &user_nickname) {
+	this->ch_operators_.push_back(user_nickname);
+}
+
+void Channel::removeChannelOperator(const std::string &user_nickname) {
+	for (std::vector<std::string>::iterator it = this->ch_operators_.begin();
+		 it != this->ch_operators_.end(); ++it) {
+		if (*it == user_nickname) {
+			it = this->ch_operators_.erase(it);
+			return;
+		}
+	}
 }
 
 enum Channel::ChannelMode Channel::getMode() const { return this->mode_; }
@@ -55,6 +78,14 @@ void Channel::printJoinedUser() const {
 	std::cout << std::endl;
 }
 
+void Channel::printChannelOperators() const {
+	std::cout << this->ch_name_ << " channel operators: ";
+	for (size_t i = 0; i < this->ch_operators_.size(); ++i) {
+		std::cout << "client[" << ch_operators_[i] << "], ";
+	}
+	std::cout << std::endl;
+}
+
 void Channel::removeUser(const int fd) {
 	printJoinedUser();
 	std::map<int, User *>::iterator it = ch_users_.find(fd);
@@ -64,4 +95,19 @@ void Channel::removeUser(const int fd) {
 		std::cerr << "cannot remove client[" << fd << "]" << std::endl;
 	}
 	printJoinedUser();
+}
+
+bool Channel::isChannelOperator(const std::string &nick_name) const {
+	return std::find(this->ch_operators_.begin(), this->ch_operators_.end(),
+					 nick_name) != ch_operators_.end();
+}
+
+bool Channel::isChannelUser(const std::string &nick_name) const {
+	for (std::map<int, User>::const_iterator it = ch_users_.begin();
+		 it != ch_users_.end(); ++it) {
+		if (nick_name == it->second.getNickName()) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -1,25 +1,25 @@
 #include "Channel.hpp"
 
-Channel::Channel() : ch_name_(""), ch_pass_(""), created_user_("") {
+Channel::Channel() : ch_name_(""), ch_pass_(""), created_user_fd_(-1) {
 	// std::cout << "Channel Constructor, ch_name_: " << this->ch_name_ <<
 	// std::endl;
 }
 
 Channel::Channel(const std::string &ch_name)
-	: ch_name_(ch_name), ch_pass_(""), created_user_("") {
+	: ch_name_(ch_name), ch_pass_(""), created_user_fd_(-1) {
 	// std::cout << "Channel Constructor, ch_name_: " << this->ch_name_ <<
 	// std::endl;
 }
 
 Channel::Channel(const std::string &name, const std::string &pass)
-	: ch_name_(name), ch_pass_(pass), created_user_("") {
+	: ch_name_(name), ch_pass_(pass), created_user_fd_(-1) {
 	// std::cout << "Channel Constructor, ch_name_: " << this->ch_name_ <<
 	// "ch_pass_: " << this->ch_pass_ << std::endl;
 }
 
 Channel::Channel(const std::string &name, const std::string &pass,
 				 const User &user)
-	: ch_name_(name), ch_pass_(pass), created_user_(user.getNickName()) {
+	: ch_name_(name), ch_pass_(pass), created_user_fd_(user.getFd()) {
 	setUser(user);
 	// std::cout << "Channel Constructor with user, ch_name_: " <<
 	// this->ch_name_
@@ -30,14 +30,24 @@ const std::string &Channel::getName() const { return (this->ch_name_); }
 
 const std::string &Channel::getPass() const { return (this->ch_pass_); }
 
-const std::vector<std::string> &Channel::getChannelOperators() const {
+const std::vector<int> &Channel::getChannelOperators() const {
 	return this->ch_operators_;
 }
 
 size_t Channel::getJoinedUserCount() const { return (this->ch_users_.size()); }
 
 const std::string &Channel::getCreatedUser() const {
-	return (this->created_user_);
+	const User *user = this->ch_users_.at(this->created_user_fd_);
+	return user->getNickName();
+}
+
+const std::vector<std::string> Channel::getChannelOperatorsNickName() const {
+	std::vector<std::string> ch_operators_nick;
+	for (size_t i = 0; i < this->ch_operators_.size(); ++i) {
+		ch_operators_nick.push_back(
+			this->ch_users_.at(this->ch_operators_.at(i))->getNickName());
+	}
+	return ch_operators_nick;
 }
 
 void Channel::setUser(const User &user) {
@@ -45,14 +55,14 @@ void Channel::setUser(const User &user) {
 	this->ch_users_[user.getFd()] = const_cast<User *>(&user);
 }
 
-void Channel::setChannelOperator(const std::string &user_nickname) {
-	this->ch_operators_.push_back(user_nickname);
+void Channel::setChannelOperator(const int user_fd) {
+	this->ch_operators_.push_back(user_fd);
 }
 
-void Channel::removeChannelOperator(const std::string &user_nickname) {
-	for (std::vector<std::string>::iterator it = this->ch_operators_.begin();
+void Channel::removeChannelOperator(const int user_fd) {
+	for (std::vector<int>::iterator it = this->ch_operators_.begin();
 		 it != this->ch_operators_.end(); ++it) {
-		if (*it == user_nickname) {
+		if (*it == user_fd) {
 			it = this->ch_operators_.erase(it);
 			return;
 		}
@@ -97,15 +107,15 @@ void Channel::removeUser(const int fd) {
 	printJoinedUser();
 }
 
-bool Channel::isChannelOperator(const std::string &nick_name) const {
+bool Channel::isChannelOperator(const int user_fd) const {
 	return std::find(this->ch_operators_.begin(), this->ch_operators_.end(),
-					 nick_name) != ch_operators_.end();
+					 user_fd) != ch_operators_.end();
 }
 
-bool Channel::isChannelUser(const std::string &nick_name) const {
-	for (std::map<int, User>::const_iterator it = ch_users_.begin();
+bool Channel::isChannelUser(const int user_fd) const {
+	for (std::map<int, User *>::const_iterator it = ch_users_.begin();
 		 it != ch_users_.end(); ++it) {
-		if (nick_name == it->second.getNickName()) {
+		if (user_fd == it->second->getFd()) {
 			return true;
 		}
 	}

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -32,7 +32,8 @@ const std::string &Channel::getPass() const { return (this->ch_pass_); }
 size_t Channel::getJoinedUserCount() const { return (this->ch_users_.size()); }
 
 void Channel::setUser(const User &user) {
-	this->ch_users_.insert(std::make_pair(user.getFd(), user));
+	// this->ch_users_.insert(std::make_pair(user.getFd(), &user));
+	this->ch_users_[user.getFd()] = const_cast<User *>(&user);
 }
 
 enum Channel::ChannelMode Channel::getMode() const { return this->mode_; }
@@ -47,7 +48,7 @@ void Channel::setMode(const enum Channel::ChannelMode mode) {
 
 void Channel::printJoinedUser() const {
 	std::cout << this->ch_name_ << " joined user: ";
-	for (std::map<int, User>::const_iterator it = ch_users_.begin();
+	for (std::map<int, User *>::const_iterator it = ch_users_.begin();
 		 it != ch_users_.end(); ++it) {
 		std::cout << "client[" << it->first << "], ";
 	}
@@ -56,7 +57,7 @@ void Channel::printJoinedUser() const {
 
 void Channel::removeUser(const int fd) {
 	printJoinedUser();
-	std::map<int, User>::iterator it = ch_users_.find(fd);
+	std::map<int, User *>::iterator it = ch_users_.find(fd);
 	if (it != ch_users_.end()) {
 		ch_users_.erase(it);
 	} else {

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -107,6 +107,13 @@ void Channel::removeUser(const int fd) {
 	printJoinedUser();
 }
 
+std::map<int, User *>::const_iterator Channel::getMapBeginIterator() const {
+	return this->ch_users_.begin();
+}
+
+std::map<int, User *>::const_iterator Channel::getMapEndIterator() const {
+	return this->ch_users_.end();
+}
 bool Channel::isChannelOperator(const int user_fd) const {
 	return std::find(this->ch_operators_.begin(), this->ch_operators_.end(),
 					 user_fd) != ch_operators_.end();

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -7,6 +7,9 @@ Command::Command(Server &server) : server_(server) {
 	this->commands_map_["JOIN"] = &Command::JOIN;
 	this->commands_map_["NICK"] = &Command::NICK;
 	this->commands_map_["USER"] = &Command::USER;
+	this->commands_map_["MODE"] = &Command::MODE;
+	this->mode_map_['O'] = &Command::handleChannelOriginOperator;
+	this->mode_map_['o'] = &Command::handleChannelOperator;
 	// std::cout << "server pass is" << server_.getPass() << std::endl;
 }
 
@@ -52,23 +55,3 @@ void Command::TEST(User &user, std::vector<std::string> &arg) {
 	this->server_.printChannelName();
 	server_.sendMsgToClient(user.getFd(), "Command => printTest: Hello world!");
 }
-
-// void Command::MOD(User &user, std::vector<std::string> &arg) {
-//	(void)arg;
-//	user.setMode(User::s);
-//	std::cout << user.getMode() << std::endl;
-//	std::cout << user.hasMode(User::s) << std::endl;
-//	std::cout << "check w" << std::endl;
-//	std::cout << user.hasMode(User::w) << std::endl;
-//	std::cout << "+w" << std::endl;
-//	user.setMode(User::w);
-//	std::cout << "check w" << std::endl;
-//	std::cout << user.hasMode(User::w) << std::endl;
-//	std::cout << "check o" << std::endl;
-//	std::cout << user.hasMode(User::o) << std::endl;
-//	std::cout << "check a" << std::endl;
-//	std::cout << user.hasMode(User::a) << std::endl;
-//	std::cout << "+a" << std::endl;
-//	user.setMode(User::a);
-//	std::cout << user.hasMode(User::a) << std::endl;
-// }

--- a/src/Command_JOIN.cpp
+++ b/src/Command_JOIN.cpp
@@ -84,7 +84,7 @@ void Command::createChannel(const std::string &ch_name,
 							const std::string &ch_key, User &user) {
 	Channel new_ch(ch_name, ch_key, user);
 	new_ch.setMode(Channel::O);
-	new_ch.setChannelOperator(user.getNickName());
+	new_ch.setChannelOperator(user.getFd());
 	this->server_.setChannel(new_ch.getName(), new_ch);
 	user.setChannel(new_ch);
 	std::cout << "finish JOIN command" << std::endl;
@@ -125,9 +125,9 @@ void Command::exitAllChannels(User &user) {
 		 it != joined_ch.end(); ++it) {
 		const std::string ch_name = *it;
 		const Channel &left_ch_const = this->server_.getChannel(ch_name);
-		if (left_ch_const.isChannelOperator(user.getNickName())) {
+		if (left_ch_const.isChannelOperator(user.getFd())) {
 			const_cast<Channel &>(left_ch_const)
-				.removeChannelOperator(user.getNickName());
+				.removeChannelOperator(user.getFd());
 		}
 		const_cast<Channel &>(left_ch_const).removeUser(user.getFd());
 		if (left_ch_const.getJoinedUserCount() == 0) {

--- a/src/Command_MODE.cpp
+++ b/src/Command_MODE.cpp
@@ -1,0 +1,196 @@
+#include "Command.hpp"
+
+void Command::MODE(User &user, std::vector<std::string> &arg) {
+	std::cout << "start MODE command" << std::endl;
+	if (user.getAuthFlags() != User::ALL_AUTH) {
+		std::cerr << "client cannot authenticate" << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  "client cannot authenticate");
+		return;
+	} else if (arg.empty() || arg.size() == 1) {
+		std::cerr << error_.ERR_NEEDMOREPARAMS("MODE") << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  error_.ERR_NEEDMOREPARAMS("MODE"));
+		return;
+	}
+	if (this->server_.hasChannelName(arg.at(0))) {
+		handleChannelMode(user, arg, this->server_.getChannel(arg.at(0)));
+	} else {
+		// handleUserMode(user, arg);
+		std::cerr << error_.ERR_NOSUCHCHANNEL("MODE") << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  error_.ERR_NOSUCHCHANNEL("MODE"));
+		return;
+	}
+}
+
+Command::ModeAction
+Command::checkModeAction(const std::string &mode_str) const {
+	if (mode_str[0] == '+') {
+		return Command::setMode;
+	} else if (mode_str[0] == '-') {
+		return Command::unsetMode;
+	} else {
+		return Command::queryMode;
+	}
+}
+
+void Command::joinStrFromVector(std::string &join_str,
+								const std::vector<std::string> &vec,
+								const std::string delimiter) {
+	for (size_t i = 0; i < vec.size(); ++i) {
+		join_str += vec.at(i);
+		if (i < vec.size() - 1) {
+			join_str += delimiter;
+		}
+	}
+}
+
+// mode "O"
+void Command::handleChannelOriginOperator(const ModeAction mode_action,
+										  User &user, const Channel &ch) {
+	if (mode_action == Command::unsetMode || mode_action == Command::setMode) {
+		std::cerr << error_.ERR_NOPRIVILEGES() << std::endl;
+		this->server_.sendMsgToClient(user.getFd(), error_.ERR_NOPRIVILEGES());
+		return;
+	} else if (this->arg_.size() > 3) {
+		std::cerr << "O: mode parameters are not required" << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  "O: mode parameters are not required");
+		return;
+	}
+	std::cout << ch.getName() << " " << ch.getCreatedUser() << std::endl;
+	this->server_.sendMsgToClient(user.getFd(),
+								  ch.getName() + " " + ch.getCreatedUser());
+}
+
+// mode "o": Give/take channel operator privilege
+void Command::handleChannelOperator(const ModeAction mode_action, User &user,
+									const Channel &ch) {
+	if (mode_action == Command::queryMode) {
+		if (this->arg_.size() > 2) {
+			std::cerr << "o: mode parameters are not required" << std::endl;
+			this->server_.sendMsgToClient(
+				user.getFd(), "o: mode parameters are not required");
+			return;
+		}
+		std::string send_str = ch.getName() + " ";
+		joinStrFromVector(send_str, ch.getChannelOperators(), ",");
+		std::cout << send_str << std::endl;
+		this->server_.sendMsgToClient(user.getFd(), send_str);
+	} else {
+		if (this->arg_.size() < 3) {
+			std::cerr << error_.ERR_NEEDMOREPARAMS("o") << std::endl;
+			this->server_.sendMsgToClient(user.getFd(),
+										  error_.ERR_NEEDMOREPARAMS("o"));
+			return;
+		}
+		std::vector<std::string> user_vec;
+		for (size_t i = 2; i < this->arg_.size(); ++i) {
+			setOrUnsetChannelOperator(i, mode_action, user, ch);
+		}
+	}
+}
+
+void Command::setOrUnsetChannelOperator(const size_t i,
+										const ModeAction mode_action,
+										User &user, const Channel &ch) {
+	if (!ch.isChannelUser(this->arg_.at(i))) {
+		std::cerr << error_.ERR_USERNOTINCHANNEL(this->arg_.at(i), ch.getName())
+				  << std::endl;
+		this->server_.sendMsgToClient(
+			user.getFd(),
+			error_.ERR_USERNOTINCHANNEL(this->arg_.at(i), ch.getName()));
+		return;
+	} else if (mode_action == Command::setMode) {
+		if (ch.isChannelOperator(this->arg_.at(i))) {
+			std::cerr << this->arg_.at(i) << " is already channel "
+					  << ch.getName() << " operator" << std::endl;
+			this->server_.sendMsgToClient(
+				user.getFd(), this->arg_.at(i) + " is already channel " +
+								  ch.getName() + " operator");
+			return;
+		}
+		const_cast<Channel &>(ch).setChannelOperator(this->arg_.at(i));
+		std::cout << ch.getName() << " " << this->arg_.at(i)
+				  << " is now channel operator" << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  ch.getName() + " " + this->arg_.at(i) +
+										  " is now channel operator");
+	} else if (mode_action == Command::unsetMode) {
+		if (this->arg_.at(i) == ch.getCreatedUser()) {
+			std::cerr << "cannot unset channel operator because "
+					  << this->arg_.at(i) << " is channel creator";
+			this->server_.sendMsgToClient(
+				user.getFd(), "cannot unset channel operator because " +
+								  this->arg_.at(i) + " is channel creator");
+			return;
+		} else if (!ch.isChannelOperator(this->arg_.at(i))) {
+			std::cerr << this->arg_.at(i) << " is already not channel "
+					  << ch.getName() << " operator" << std::endl;
+			this->server_.sendMsgToClient(
+				user.getFd(), this->arg_.at(i) + " is already not channel " +
+								  ch.getName() + " operator");
+			return;
+		}
+		const_cast<Channel &>(ch).removeChannelOperator(this->arg_.at(i));
+		std::cout << ch.getName() << " " << this->arg_.at(i)
+				  << " is now not channel operator" << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  ch.getName() + " " + this->arg_.at(i) +
+										  " is now not channel operator");
+	}
+}
+
+bool Command::checkInvalidSignsCount(const std::string &mode_str) {
+	int count = 0;
+	for (size_t i = 0; i < mode_str.size(); ++i) {
+		if (mode_str[i] == '+' || mode_str[i] == '-') {
+			count++;
+		}
+		if (count > 1) {
+			return false;
+		}
+	}
+	return true;
+}
+
+void Command::handleChannelMode(User &user, std::vector<std::string> &arg,
+								const Channel &ch) {
+	size_t i = 0;
+	std::string mode_str = arg.at(1);
+	if (!checkInvalidSignsCount(mode_str)) {
+		std::cerr << error_.ERR_UMODEUNKNOWNFLAG(mode_str) << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  error_.ERR_UMODEUNKNOWNFLAG(mode_str));
+		return;
+	}
+	ModeAction mode_action = checkModeAction(mode_str);
+	if ((mode_action == Command::setMode ||
+		 mode_action == Command::unsetMode) &&
+		!ch.isChannelOperator(user.getNickName())) {
+		std::cerr << error_.ERR_CHANOPRIVSNEEDED(ch.getName()) << std::endl;
+		this->server_.sendMsgToClient(
+			user.getFd(), error_.ERR_CHANOPRIVSNEEDED(ch.getName()));
+		return;
+	}
+	if (mode_action == Command::setMode || mode_action == Command::unsetMode) {
+		i++;
+	}
+	std::cout << "start handleChannelMode: " << mode_action << std::endl;
+	for (; i < mode_str.size(); ++i) {
+		char mode_type = mode_str[i];
+		ModeFunction mode_func = this->mode_map_[mode_type];
+		if (!mode_func) {
+			std::cerr << error_.ERR_UNKNOWNMODE(std::string(1, mode_type),
+												ch.getName())
+					  << std::endl;
+			this->server_.sendMsgToClient(
+				user.getFd(), error_.ERR_UNKNOWNMODE(std::string(1, mode_type),
+													 ch.getName()));
+			continue;
+		}
+		std::cout << "mode_type: " << mode_type << std::endl;
+		(this->*mode_func)(mode_action, user, ch);
+	}
+}

--- a/src/Command_NICK.cpp
+++ b/src/Command_NICK.cpp
@@ -70,11 +70,15 @@ void Command::NICK(User &user, std::vector<std::string> &arg) {
 	} else {
 		server_.nicknameInsertLog(arg.at(0));
 		user.setNickname(arg.at(0));
-		if (user.getAuthFlags() == User::USER_AUTH) {
+		if (user.getAuthFlags() == User::ALL_AUTH) {
+			this->server_.sendMsgToClient(user.getFd(), "NICK rename success");
+			return;
+		} else if (user.getAuthFlags() == User::USER_AUTH) {
 			user.setAuthFlags(User::ALL_AUTH);
 		} else {
 			user.setAuthFlags(User::NICK_AUTH);
 		}
+		std::cout << user.getAuthFlags() << std::endl;
 		server_.sendMsgToClient(user.getFd(), "NICK name success");
 	}
 }

--- a/src/Command_USER.cpp
+++ b/src/Command_USER.cpp
@@ -47,6 +47,7 @@ void Command::USER(User &user, std::vector<std::string> &arg) {
 		} else {
 			user.setAuthFlags(User::USER_AUTH);
 		}
+		std::cout << user.getAuthFlags() << std::endl;
 		std::cout << "realname: " << user.getRealName() << std::endl;
 		std::cout << "nickname: " << user.getNickName() << std::endl;
 		std::cout << "username: " << user.getUserName() << std::endl;

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -59,3 +59,7 @@ std::string Error::ERR_USERNOTINCHANNEL(const std::string &nick_name,
 										const std::string &ch_name) const {
 	return nick_name + " " + ch_name + " They aren't on that channel";
 }
+
+std::string Error::ERR_NOSUCHNICK(const std::string &nick) const {
+	return nick + " :No such nick";
+}

--- a/src/Error.cpp
+++ b/src/Error.cpp
@@ -37,3 +37,25 @@ std::string Error::ERR_NOSUCHCHANNEL(const std::string &ch_name) const {
 std::string Error::ERR_BADCHANNELKEY(const std::string &ch_name) const {
 	return ch_name + ":Cannot join channel (+k)";
 }
+
+std::string Error::ERR_CHANOPRIVSNEEDED(const std::string &ch_name) const {
+	return ch_name + ":You're not channel operator";
+}
+
+std::string Error::ERR_UNKNOWNMODE(const std::string &c,
+								   const std::string &ch_name) const {
+	return c + ":is unknown mode char to me for " + ch_name;
+}
+
+std::string Error::ERR_NOPRIVILEGES() const {
+	return ":Permission Denied- You're not an IRC operator";
+}
+
+std::string Error::ERR_UMODEUNKNOWNFLAG(const std::string &mode_flag) const {
+	return mode_flag + ":Unknown MODE flag";
+}
+
+std::string Error::ERR_USERNOTINCHANNEL(const std::string &nick_name,
+										const std::string &ch_name) const {
+	return nick_name + " " + ch_name + " They aren't on that channel";
+}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -159,7 +159,7 @@ std::string Server::recvCmdFromClient(const size_t i) {
 	return (recv_msg);
 }
 
-void Server::sendMsgToClient(const int fd, const std::string &send_str) {
+void Server::sendMsgToClient(const int fd, const std::string &send_str) const {
 	// std::cout << "start sendMsgToClient" << std::endl;
 	char send_msg[BUF_SIZE];
 	if (send_str.size() + 1 > BUF_SIZE - 1) {
@@ -179,7 +179,8 @@ void Server::removeChannel(const std::string &ch_name) {
 	std::cout << "remove Channel: " << ch_name << std::endl;
 }
 
-void Server::exit_error(const std::string &func, const std::string &err_msg) {
+void Server::exit_error(const std::string &func,
+						const std::string &err_msg) const {
 	std::cerr << "ERROR: " << func << ": " << err_msg << std::endl;
 	std::exit(EXIT_FAILURE);
 }
@@ -204,7 +205,7 @@ void Server::setChannel(const std::string &ch_name, const Channel &ch) {
 	this->ch_map_.insert(std::make_pair(ch_name, ch));
 }
 
-bool Server::hasChannelName(const std::string &ch_name) {
+bool Server::hasChannelName(const std::string &ch_name) const {
 	return ch_map_.find(ch_name) != ch_map_.end();
 }
 
@@ -222,6 +223,18 @@ bool Server::nicknameExist(const std::string &nickname) const {
 
 void Server::nicknameInsertLog(std::string nickname) {
 	this->nickname_log_.insert(nickname);
+}
+
+void Server::sendToChannelUser(std::string &ch_name, std::string &msg) const {
+	if (!hasChannelName(ch_name))
+		return;
+	const Channel &ch = getChannel(ch_name);
+	std::map<int, User *>::const_iterator iter =
+		const_cast<Channel &>(ch).getMapBeginIterator();
+	while (iter != const_cast<Channel &>(ch).getMapEndIterator()) {
+		sendMsgToClient(iter->second->getFd(), msg);
+		++iter;
+	}
 }
 
 bool Server::isUser(const std::string &nickname) const {

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -190,6 +190,16 @@ const Channel &Server::getChannel(const std::string &ch_name) const {
 	return ch_map_.find(ch_name)->second;
 }
 
+const User &Server::getUser(const std::string &nickname) const {
+	for (std::map<int, User>::const_iterator it = user_map_.begin();
+		 it != user_map_.end(); ++it) {
+		if (nickname == it->second.getNickName()) {
+			return it->second;
+		}
+	}
+	throw std::runtime_error("cannot find user");
+}
+
 void Server::setChannel(const std::string &ch_name, const Channel &ch) {
 	this->ch_map_.insert(std::make_pair(ch_name, ch));
 }
@@ -212,6 +222,16 @@ bool Server::nicknameExist(const std::string &nickname) const {
 
 void Server::nicknameInsertLog(std::string nickname) {
 	this->nickname_log_.insert(nickname);
+}
+
+bool Server::isUser(const std::string &nickname) const {
+	for (std::map<int, User>::const_iterator it = user_map_.begin();
+		 it != user_map_.end(); ++it) {
+		if (nickname == it->second.getNickName()) {
+			return true;
+		}
+	}
+	return false;
 }
 
 Server::~Server() {}


### PR DESCRIPTION
[body]
- `User` オブジェクトの代わりに `User` オブジェクトのポインターを格納するように `Channel.hpp` 内の `ch_users_` マップを更新。
- 新しいポインターベースのユーザー管理に適応するために、`Channel.cpp` を修正。これには、ユーザーポインタを扱うように `setUser`、`printJoinedUser`、および `removeUser` メソッドを変更し、ユーザー管理が一貫性があり、メモリ効率的であることを保証することが含まれます。

[notes]
- メモリリークやダングリングポインターを防ぐために、`User` オブジェクトのライフサイクルが `Channel` クラスの外部で管理されるように注意する必要があります。
- これらの変更が新しい問題を導入していないことを保証するために、特にユーザーの切断やチャネルの削除を含むエッジケースで、さらなるテストが必要になるかもしれません。 close #112