### PR TITLE
50 feat topic command, 99 mode t flag

### DIFF
--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -46,11 +46,13 @@ class Channel {
 	const std::vector<std::string> getInvitedUsersNickName() const;
 	const std::string &getCreatedUser() const;
 	const ssize_t &getMaxUsers() const;
+	const std::string &getTopicStr() const;
 	void setUser(const User &user);
 	void setPass(const std::string &pass);
 	void setChannelOperator(const int user_fd);
 	void setMaxUsers(const int max_users);
 	void setInvitedUser(const int user_fd);
+	void setTopicStr(const std::string &str);
 	void removeChannelOperator(const int user_fd);
 	enum ChannelMode getMode() const;
 	void setMode(const enum ChannelMode mode);
@@ -74,6 +76,7 @@ class Channel {
 	std::vector<int> ch_operators_;
 	std::vector<int> invited_users_;
 	ssize_t max_users_;
+	std::string topic_str_;
 };
 
 #endif

--- a/include/Command.hpp
+++ b/include/Command.hpp
@@ -98,6 +98,7 @@ class Command {
 	void TOPIC(User &user, std::vector<std::string> &arg);
 	void queryChannelTopic(User &user, const Channel &topic_ch);
 	void removeChannelTopic(User &user, const Channel &topic_ch);
+	void setChannelTopic(User &user, const Channel &topic_ch);
 
 	// MODE
 	void MODE(User &user, std::vector<std::string> &arg);
@@ -134,6 +135,9 @@ class Command {
 	void queryInviteOnly(User &user, const Channel &ch);
 	void setInviteOnly(User &user, const Channel &ch);
 	void unsetInviteOnly(User &user, const Channel &ch);
+	// mode 't'
+	void handleTopicOnlyOperator(const ModeAction mode_action, User &user,
+								 const Channel &ch);
 };
 
 #endif

--- a/include/Command.hpp
+++ b/include/Command.hpp
@@ -94,6 +94,11 @@ class Command {
 	// INVITE
 	void INVITE(User &user, std::vector<std::string> &arg);
 
+	// TOPIC
+	void TOPIC(User &user, std::vector<std::string> &arg);
+	void queryChannelTopic(User &user, const Channel &topic_ch);
+	void removeChannelTopic(User &user, const Channel &topic_ch);
+
 	// MODE
 	void MODE(User &user, std::vector<std::string> &arg);
 	void handleChannelMode(User &user, std::vector<std::string> &arg,

--- a/include/Reply.hpp
+++ b/include/Reply.hpp
@@ -14,6 +14,7 @@
 
 class Reply {
   public:
+	// ERR
 	std::string ERR_NEEDMOREPARAMS(const std::string &command) const;
 	std::string ERR_ALREADYREGISTRED() const;
 	std::string ERR_PASSWDMISMATCH() const;
@@ -37,8 +38,14 @@ class Reply {
 	std::string ERR_CHANNELISFULL(const std::string &ch_name) const;
 	std::string ERR_INVITEONLYCHAN(const std::string &ch_name) const;
 
+	std::string ERR_NOTONCHANNEL(const std::string &ch_name) const;
+
+	// RPL
 	std::string RPL_WELCOME(const std::string &nick,
 							const std::string &user) const;
+	std::string RPL_NOTOPIC(const std::string &ch_name) const;
+	std::string RPL_TOPIC(const std::string &ch_name,
+						  const std::string &topic_str) const;
 };
 
 #endif

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -66,6 +66,8 @@ const std::vector<std::string> Channel::getInvitedUsersNickName() const {
 
 const ssize_t &Channel::getMaxUsers() const { return this->max_users_; }
 
+const std::string &Channel::getTopicStr() const { return this->topic_str_; }
+
 void Channel::setUser(const User &user) {
 	// this->ch_users_.insert(std::make_pair(user.getFd(), &user));
 	this->ch_users_[user.getFd()] = const_cast<User *>(&user);
@@ -82,6 +84,8 @@ void Channel::setMaxUsers(const int max_users) { this->max_users_ = max_users; }
 void Channel::setInvitedUser(const int user_fd) {
 	this->invited_users_.push_back(user_fd);
 }
+
+void Channel::setTopicStr(const std::string &str) { this->topic_str_ = str; }
 
 void Channel::removeChannelOperator(const int user_fd) {
 	for (std::vector<int>::iterator it = this->ch_operators_.begin();

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -16,6 +16,7 @@ Command::Command(Server &server) : server_(server) {
 	this->mode_map_['l'] = &Command::handleLimitedUserNum;
 	this->mode_map_['l'] = &Command::handleLimitedUserNum;
 	this->mode_map_['i'] = &Command::handleInviteOnly;
+	this->mode_map_['t'] = &Command::handleTopicOnlyOperator;
 	// std::cout << "server pass is" << server_.getPass() << std::endl;
 }
 

--- a/src/Command.cpp
+++ b/src/Command.cpp
@@ -9,6 +9,7 @@ Command::Command(Server &server) : server_(server) {
 	this->commands_map_["JOIN"] = &Command::JOIN;
 	this->commands_map_["MODE"] = &Command::MODE;
 	this->commands_map_["INVITE"] = &Command::INVITE;
+	this->commands_map_["TOPIC"] = &Command::TOPIC;
 	this->mode_map_['O'] = &Command::handleChannelOriginOperator;
 	this->mode_map_['o'] = &Command::handleChannelOperator;
 	this->mode_map_['k'] = &Command::handleChannelKey;

--- a/src/Command_MODE.cpp
+++ b/src/Command_MODE.cpp
@@ -403,6 +403,57 @@ void Command::unsetInviteOnly(User &user, const Channel &ch) {
 								  ch.getName() + " is now unset i mode");
 }
 
+// mode "t":Set/remove the restrictions of the TOPIC command to channel
+// operators
+void Command::handleTopicOnlyOperator(const ModeAction mode_action, User &user,
+									  const Channel &ch) {
+	if (!ch.isChannelOperator(user.getFd())) {
+		std::cerr << reply_.ERR_CHANOPRIVSNEEDED(ch.getName()) << std::endl;
+		this->server_.sendMsgToClient(
+			user.getFd(), reply_.ERR_CHANOPRIVSNEEDED(ch.getName()));
+		return;
+	} else if (this->arg_.size() > 2) {
+		std::cerr << reply_.ERR_TOOMANYPARAMS("Mode t flag") << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  reply_.ERR_TOOMANYPARAMS("Mode t flag"));
+		return;
+	} else if (this->arg_.size() < 2) {
+		std::cerr << reply_.ERR_NEEDMOREPARAMS("Mode t flag") << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  reply_.ERR_NEEDMOREPARAMS("Mode t flag"));
+		return;
+	} else if (mode_action == Command::queryMode) {
+		std::cerr << reply_.ERR_UMODEUNKNOWNFLAG("t") << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  reply_.ERR_UMODEUNKNOWNFLAG("t"));
+		return;
+	}
+	if (mode_action == Command::setMode) {
+		if (ch.hasMode(Channel::t)) {
+			std::cerr << ch.getName() << " is already set t mode" << std::endl;
+			this->server_.sendMsgToClient(
+				user.getFd(), ch.getName() + " is already set t mode");
+			return;
+		}
+		const_cast<Channel &>(ch).setMode(Channel::t);
+		std::cout << ch.getName() << " is now set t mode" << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  ch.getName() + " is now set t mode");
+	} else {
+		if (!ch.hasMode(Channel::t)) {
+			std::cerr << ch.getName() << " is already not set t mode"
+					  << std::endl;
+			this->server_.sendMsgToClient(
+				user.getFd(), ch.getName() + " is already not set t mode");
+			return;
+		}
+		const_cast<Channel &>(ch).unsetMode(Channel::t);
+		std::cout << ch.getName() << " is now unset t mode" << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  ch.getName() + " is now unset t mode");
+	}
+}
+
 bool Command::checkInvalidSignsCount(const std::string &mode_str) {
 	int count = 0;
 	for (size_t i = 0; i < mode_str.size(); ++i) {

--- a/src/Command_TOPIC.cpp
+++ b/src/Command_TOPIC.cpp
@@ -28,7 +28,8 @@ void Command::TOPIC(User &user, std::vector<std::string> &arg) {
 	}
 	if (arg.size() == 1) {
 		queryChannelTopic(user, topic_ch);
-	} else if (arg.size() == 2 && arg.at(1)[0] == ':') {
+	} else if (arg.size() == 2 && arg.at(1).size() == 1 &&
+			   arg.at(1)[0] == ':') {
 		removeChannelTopic(user, topic_ch);
 	} else {
 		setChannelTopic(user, topic_ch);
@@ -50,18 +51,10 @@ void Command::queryChannelTopic(User &user, const Channel &topic_ch) {
 }
 
 void Command::removeChannelTopic(User &user, const Channel &topic_ch) {
-	if (topic_ch.getTopicStr() == "") {
-		std::cout << reply_.RPL_NOTOPIC(topic_ch.getName());
-		this->server_.sendMsgToClient(user.getFd(),
-									  reply_.RPL_NOTOPIC(topic_ch.getName()));
-	} else {
-		const_cast<Channel &>(topic_ch).setTopicStr("");
-		std::cout << reply_.RPL_TOPIC(topic_ch.getName(),
-									  topic_ch.getTopicStr());
-		this->server_.sendMsgToClient(
-			user.getFd(),
-			reply_.RPL_TOPIC(topic_ch.getName(), topic_ch.getTopicStr()));
-	}
+	const_cast<Channel &>(topic_ch).setTopicStr("");
+	std::cout << reply_.RPL_NOTOPIC(topic_ch.getName());
+	this->server_.sendMsgToClient(user.getFd(),
+								  reply_.RPL_NOTOPIC(topic_ch.getName()));
 }
 
 void Command::setChannelTopic(User &user, const Channel &topic_ch) {

--- a/src/Command_TOPIC.cpp
+++ b/src/Command_TOPIC.cpp
@@ -1,0 +1,65 @@
+#include "Command.hpp"
+
+void Command::TOPIC(User &user, std::vector<std::string> &arg) {
+	std::cout << "start TOPIC" << std::endl;
+	if (arg.empty()) {
+		std::cerr << reply_.ERR_NEEDMOREPARAMS("TOPIC") << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  reply_.ERR_NEEDMOREPARAMS("TOPIC"));
+		return;
+	} else if (!this->server_.hasChannelName(arg.at(0))) {
+		std::cerr << reply_.ERR_NOSUCHCHANNEL(arg.at(0)) << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  reply_.ERR_NOSUCHCHANNEL(arg.at(0)));
+		return;
+	}
+	const Channel &topic_ch = this->server_.getChannel(arg.at(0));
+	if (topic_ch.hasMode(Channel::t) &&
+		!topic_ch.isChannelOperator(user.getFd())) {
+		std::cerr << reply_.ERR_CHANOPRIVSNEEDED(arg.at(0)) << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  reply_.ERR_CHANOPRIVSNEEDED(arg.at(0)));
+		return;
+	} else if (!topic_ch.isChannelUser(user.getFd())) {
+		std::cerr << reply_.ERR_NOTONCHANNEL(arg.at(0)) << std::endl;
+		this->server_.sendMsgToClient(user.getFd(),
+									  reply_.ERR_NOTONCHANNEL(arg.at(0)));
+		return;
+	}
+	if (arg.size() == 1) {
+		queryChannelTopic(user, topic_ch);
+	} else if (arg.size() == 2 && arg.at(1)[0] == ':') {
+		removeChannelTopic(user, topic_ch);
+	} else {
+		// setChannelTopic();
+	}
+}
+
+void Command::queryChannelTopic(User &user, const Channel &topic_ch) {
+	if (topic_ch.getTopicStr() == "") {
+		std::cout << reply_.RPL_NOTOPIC(topic_ch.getName());
+		this->server_.sendMsgToClient(user.getFd(),
+									  reply_.RPL_NOTOPIC(topic_ch.getName()));
+	} else {
+		std::cout << reply_.RPL_TOPIC(topic_ch.getName(),
+									  topic_ch.getTopicStr());
+		this->server_.sendMsgToClient(
+			user.getFd(),
+			reply_.RPL_TOPIC(topic_ch.getName(), topic_ch.getTopicStr()));
+	}
+}
+
+void Command::removeChannelTopic(User &user, const Channel &topic_ch) {
+	if (topic_ch.getTopicStr() == "") {
+		std::cout << reply_.RPL_NOTOPIC(topic_ch.getName());
+		this->server_.sendMsgToClient(user.getFd(),
+									  reply_.RPL_NOTOPIC(topic_ch.getName()));
+	} else {
+		const_cast<Channel &>(topic_ch).setTopicStr("");
+		std::cout << reply_.RPL_TOPIC(topic_ch.getName(),
+									  topic_ch.getTopicStr());
+		this->server_.sendMsgToClient(
+			user.getFd(),
+			reply_.RPL_TOPIC(topic_ch.getName(), topic_ch.getTopicStr()));
+	}
+}

--- a/src/Command_TOPIC.cpp
+++ b/src/Command_TOPIC.cpp
@@ -31,7 +31,7 @@ void Command::TOPIC(User &user, std::vector<std::string> &arg) {
 	} else if (arg.size() == 2 && arg.at(1)[0] == ':') {
 		removeChannelTopic(user, topic_ch);
 	} else {
-		// setChannelTopic();
+		setChannelTopic(user, topic_ch);
 	}
 }
 
@@ -62,4 +62,29 @@ void Command::removeChannelTopic(User &user, const Channel &topic_ch) {
 			user.getFd(),
 			reply_.RPL_TOPIC(topic_ch.getName(), topic_ch.getTopicStr()));
 	}
+}
+
+void Command::setChannelTopic(User &user, const Channel &topic_ch) {
+	std::string topic_msg;
+	// if (this->arg_.at(1)[0] == ':') {
+	// 	topic_msg += this->arg_.at(1).substr(1);
+	// } else {
+	// 	topic_msg += this->arg_.at(1);
+	// }
+	for (size_t i = 1; i < this->arg_.size(); ++i) {
+		if (i == 1 && this->arg_.at(i)[0] == ':') {
+			topic_msg += this->arg_.at(1).substr(1);
+		} else {
+			topic_msg += this->arg_.at(i);
+		}
+		if (i < this->arg_.size() - 1) {
+			topic_msg += " ";
+		}
+	}
+	std::cout << "topic_msg: " << topic_msg << std::endl;
+	const_cast<Channel &>(topic_ch).setTopicStr(topic_msg);
+	std::cout << reply_.RPL_TOPIC(topic_ch.getName(), topic_ch.getTopicStr());
+	this->server_.sendMsgToClient(
+		user.getFd(),
+		reply_.RPL_TOPIC(topic_ch.getName(), topic_ch.getTopicStr()));
 }

--- a/src/Reply.cpp
+++ b/src/Reply.cpp
@@ -64,11 +64,6 @@ std::string Reply::ERR_NOSUCHNICK(const std::string &nick) const {
 	return nick + " :No such nick";
 }
 
-std::string Reply::RPL_WELCOME(const std::string &nick,
-							   const std::string &user) const {
-	return "Welcome to the Internet Relay Network " + nick + "!" + user + "@";
-}
-
 std::string Reply::ERR_CHANNELISFULL(const std::string &ch_name) const {
 	return ch_name + " :Cannot join channel (+l)";
 }
@@ -79,4 +74,24 @@ std::string Reply::ERR_TOOMANYPARAMS(const std::string &command) const {
 
 std::string Reply::ERR_INVITEONLYCHAN(const std::string &ch_name) const {
 	return ch_name + " :Cannot join channel (+i)";
+}
+
+std::string Reply::ERR_NOTONCHANNEL(const std::string &ch_name) const {
+	return ch_name + " :You're not on that channel";
+}
+
+// RPL
+
+std::string Reply::RPL_WELCOME(const std::string &nick,
+							   const std::string &user) const {
+	return "Welcome to the Internet Relay Network " + nick + "!" + user + "@";
+}
+
+std::string Reply::RPL_NOTOPIC(const std::string &ch_name) const {
+	return ch_name + " :No topic is set";
+}
+
+std::string Reply::RPL_TOPIC(const std::string &ch_name,
+							 const std::string &topic_str) const {
+	return ch_name + " :" + topic_str;
 }


### PR DESCRIPTION
- Topicコマンドを実装しました
- Topicコマンドを使用できるのをチャンネルオペレーターに制限するModeコマンドのtフラグを実装しました
- ex)
```
TOPIC #test :another topic
    ; #test のトピックを "another topic" に設定するコマンド。

TOPIC #test :
    ; #test のトピックを消去するコマンド。

TOPIC #test
    ; #test のトピックを確認するコマンド。
```
