### PR TITLE
refactor 137 remove EAGAIN

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -142,9 +142,6 @@ std::string Server::recvCmdFromClient(const size_t i) {
 				  << std::endl;
 		return ("ERROR: received message exceeds 510 characters limit");
 	} else if (recv_size == -1) {
-		if (errno == EAGAIN) {
-			throw std::runtime_error("not yet finished sending from client");
-		}
 		close(this->pollfd_vec_[i].fd);
 		close(this->server_sockfd_);
 		exit_error("recv", strerror(errno));
@@ -168,7 +165,7 @@ void Server::sendMsgToClient(const int fd, const std::string &send_str) const {
 		std::strcpy(send_msg, send_str.c_str());
 	}
 	std::strcat(send_msg, "\n");
-	int send_size = send(fd, &send_msg, std::strlen(send_msg), 0);
+	int send_size = send(fd, &send_msg, std::strlen(send_msg), MSG_DONTWAIT);
 	if (send_size == -1) {
 		exit_error("send", strerror(errno));
 	}


### PR DESCRIPTION
[body]
- send()とrecv()に必要なEAGAINを消しました。(評価項目にEAGAINを使ってはいけないと書いてあるそうです)
- send()をノンブロッキング状態にしました。(subjectに"All I/O operations must be non-blocking"と書いてあったので)

[notes]

close #137