### PR TITLE
[feat]: #159 add invited_user_ in User class

### DIFF
--- a/include/Channel.hpp
+++ b/include/Channel.hpp
@@ -42,9 +42,10 @@ class Channel {
 	const std::string &getPass() const;
 	const std::vector<int> &getChannelOperators() const;
 	size_t getJoinedUserCount() const;
+	size_t getInvitedUsersCount() const;
 	const std::vector<std::string> getChannelOperatorsNickName() const;
 	const std::vector<int> &getInvitedUsers() const;
-	const std::string &getCreatedUser() const;
+	const std::string getCreatedUser() const;
 	const ssize_t &getMaxUsers() const;
 	const std::string &getTopicStr() const;
 	void setUser(const User &user);
@@ -53,6 +54,7 @@ class Channel {
 	void setMaxUsers(const int max_users);
 	void setInvitedUser(const int user_fd);
 	void setTopicStr(const std::string &str);
+	void setChannelCreater(const int user_fd);
 	void removeChannelOperator(const int user_fd);
 	enum ChannelMode getMode() const;
 	void setMode(const enum ChannelMode mode);
@@ -66,6 +68,7 @@ class Channel {
 	bool isChannelOperator(const int user_fd) const;
 	bool isChannelUser(const int user_fd) const;
 	bool isInvitedUser(const int user_fd) const;
+	bool isChannelCreater(const int user_fd) const;
 	void removeInvitedUser(const int user_fd);
 
   private:

--- a/include/Command.hpp
+++ b/include/Command.hpp
@@ -25,6 +25,7 @@ class Command {
 	Command(Server &server);
 	void handleCommand(User &user, std::string &message);
 	void quitAllChannels(User &user, std::string broadcast_msg);
+	void removeAllInvitedChannels(User &user);
 
   private:
 	enum ModeAction { setMode, unsetMode, queryMode };

--- a/include/User.hpp
+++ b/include/User.hpp
@@ -43,12 +43,15 @@ class User {
 	const std::string &getRealName() const;
 	const std::string &getUserName() const;
 	size_t getJoinedChannelCount() const;
+	size_t getInvitedChannelCount() const;
 	const std::set<std::string> &getJoinedChannels() const;
+	const std::vector<std::string> &getInvitedChannel() const;
 	enum UserMode getMode() const;
 	void setAuthFlags(const AuthFlags &flags);
 	void setNickname(const std::string &nickname);
 	void setUsername(const std::string &username);
 	void setRealName(const std::string &real_name);
+	void setInvitedChannel(const std::string &ch_name);
 	bool isUsernameSet() const;
 	void setMode(const enum UserMode mode);
 	void unsetMode(const enum UserMode mode);
@@ -60,6 +63,7 @@ class User {
 	void printJoinChannel() const;
 
 	void removeChannel(const std::string &ch_name);
+	void removeInvitedChannel(const std::string &ch_name);
 
   private:
 	const int fd_;
@@ -69,6 +73,7 @@ class User {
 	std::string user_name_;
 	std::string real_name_;
 	std::set<std::string> ch_set_;
+	std::vector<std::string> invited_ch_;
 	// std::map<std::string, Channel> ch_map_;
 };
 

--- a/include/User.hpp
+++ b/include/User.hpp
@@ -45,7 +45,7 @@ class User {
 	size_t getJoinedChannelCount() const;
 	size_t getInvitedChannelCount() const;
 	const std::set<std::string> &getJoinedChannels() const;
-	const std::vector<std::string> &getInvitedChannel() const;
+	const std::vector<std::string> &getInvitedChannels() const;
 	enum UserMode getMode() const;
 	void setAuthFlags(const AuthFlags &flags);
 	void setNickname(const std::string &nickname);

--- a/src/Channel.cpp
+++ b/src/Channel.cpp
@@ -41,7 +41,14 @@ const std::vector<int> &Channel::getChannelOperators() const {
 
 size_t Channel::getJoinedUserCount() const { return (this->ch_users_.size()); }
 
-const std::string &Channel::getCreatedUser() const {
+size_t Channel::getInvitedUsersCount() const {
+	return (this->invited_users_.size());
+}
+
+const std::string Channel::getCreatedUser() const {
+	if (created_user_fd_ == -1) {
+		return "there is already no channel created user";
+	}
 	const User *user = this->ch_users_.at(this->created_user_fd_);
 	return user->getNickName();
 }
@@ -81,6 +88,10 @@ void Channel::setInvitedUser(const int user_fd) {
 }
 
 void Channel::setTopicStr(const std::string &str) { this->topic_str_ = str; }
+
+void Channel::setChannelCreater(const int user_fd) {
+	this->created_user_fd_ = user_fd;
+}
 
 void Channel::removeChannelOperator(const int user_fd) {
 	for (std::vector<int>::iterator it = this->ch_operators_.begin();
@@ -160,6 +171,10 @@ bool Channel::isChannelUser(const int user_fd) const {
 bool Channel::isInvitedUser(const int user_fd) const {
 	return std::find(this->invited_users_.begin(), this->invited_users_.end(),
 					 user_fd) != invited_users_.end();
+}
+
+bool Channel::isChannelCreater(const int user_fd) const {
+	return this->created_user_fd_ == user_fd;
 }
 
 void Channel::removeInvitedUser(const int user_fd) {

--- a/src/Command_INVITE.cpp
+++ b/src/Command_INVITE.cpp
@@ -49,6 +49,7 @@ void Command::INVITE(User &user, std::vector<std::string> &arg) {
 		return;
 	}
 	const_cast<Channel &>(invite_ch).setInvitedUser(invite_user.getFd());
+	const_cast<User &>(invite_user).setInvitedChannel(invite_ch.getName());
 	std::cout << invite_ch.getName() << " " << invite_user.getNickName()
 			  << std::endl;
 	this->server_.sendMsgToClient(user.getFd(), invite_ch.getName() + " " +

--- a/src/Command_JOIN.cpp
+++ b/src/Command_JOIN.cpp
@@ -88,6 +88,7 @@ void Command::joinChannel(const std::string &ch_name, const std::string &ch_key,
 	const_cast<Channel &>(join_ch).setUser(user);
 	if (join_ch.isInvitedUser(user.getFd())) {
 		const_cast<Channel &>(join_ch).removeInvitedUser(user.getFd());
+		user.removeInvitedChannel(join_ch.getName());
 	}
 	std::cout << "finish JOIN command" << std::endl;
 	user.printJoinChannel();
@@ -158,7 +159,7 @@ void Command::exitAllChannels(User &user) {
 		}
 		this->server_.sendToChannelAllUser(left_ch_const.getName(), user,
 										   user.getNickName() +
-											" has left this channel");
+											   " has left this channel");
 		const_cast<Channel &>(left_ch_const).removeUser(user.getFd());
 		if (left_ch_const.getJoinedUserCount() == 0) {
 			this->server_.removeChannel(left_ch_const.getName());
@@ -181,6 +182,7 @@ void Command::JOIN(User &user, std::vector<std::string> &arg) {
 	}
 	if (arg.at(0) == "0") {
 		exitAllChannels(user);
+		removeAllInvitedChannels(user);
 		std::cout << "finish JOIN 0 command" << std::endl;
 		user.printJoinChannel();
 		this->server_.sendMsgToClient(user.getFd(), "SUCCESS: JOIN 0 Command");

--- a/src/Command_KILL.cpp
+++ b/src/Command_KILL.cpp
@@ -31,6 +31,7 @@ void Command::KILL(User &user, std::vector<std::string> &arg) {
 	this->server_.sendMsgToClient(fd, reply_.RPL_KILL(user.getNickName(),
 													  kill_user.getNickName(),
 													  kill_comment));
+	removeAllInvitedChannels(const_cast<User &>(kill_user));
 	quitAllChannels(const_cast<User &>(kill_user), kill_comment);
 	this->server_.removeUser(fd);
 	this->server_.removePollfd(fd);

--- a/src/Command_MODE.cpp
+++ b/src/Command_MODE.cpp
@@ -125,9 +125,6 @@ void Command::joinStrFromVector(std::string &join_str, const Channel &ch,
 	std::cout << "start joinStrFromVector" << std::endl;
 	std::vector<std::string> vec = ch.getChannelOperatorsNickName();
 	for (size_t i = 0; i < vec.size(); ++i) {
-		std::cout << vec[i] << std::endl;
-	}
-	for (size_t i = 0; i < vec.size(); ++i) {
 		join_str += vec.at(i);
 		if (i < vec.size() - 1) {
 			join_str += delimiter;
@@ -447,12 +444,12 @@ void Command::handleInviteOnly(const ModeAction mode_action, User &user,
 }
 
 void Command::queryInviteOnly(User &user, const Channel &ch) {
-	const std::vector<int> &invited_user = ch.getInvitedUsers();
-	if (invited_user.empty()) {
+	if (ch.getInvitedUsersCount() == 0) {
 		std::cerr << "no invited users" << std::endl;
 		this->server_.sendMsgToClient(user.getFd(), "no invited users");
 		return;
 	}
+	const std::vector<int> &invited_user = ch.getInvitedUsers();
 	std::ostringstream oss;
 	oss << ch.getName() << " invited users: ";
 	for (size_t i = 0; i < invited_user.size(); ++i) {

--- a/src/Command_QUIT.cpp
+++ b/src/Command_QUIT.cpp
@@ -30,7 +30,7 @@ void Command::removeAllInvitedChannels(User &user) {
 	if (user.getInvitedChannelCount() == 0) {
 		return;
 	}
-	const std::vector<std::string> &invited_ch = user.getInvitedChannel();
+	const std::vector<std::string> &invited_ch = user.getInvitedChannels();
 	for (std::vector<std::string>::const_iterator it = invited_ch.begin();
 		 it != invited_ch.end(); ++it) {
 		const std::string &ch_name = *it;

--- a/src/Command_QUIT.cpp
+++ b/src/Command_QUIT.cpp
@@ -12,6 +12,9 @@ void Command::quitAllChannels(User &user, std::string broadcast_msg) {
 			const_cast<Channel &>(left_ch_const)
 				.removeChannelOperator(user.getFd());
 		}
+		if (left_ch_const.isChannelCreater(user.getFd())) {
+			const_cast<Channel &>(left_ch_const).setChannelCreater(-1);
+		}
 		// remove from all invite lists
 		// send broadcast_msg to all channel members
 		this->server_.sendToChannelAllUser(left_ch_const.getName(), user,
@@ -20,6 +23,19 @@ void Command::quitAllChannels(User &user, std::string broadcast_msg) {
 		if (left_ch_const.getJoinedUserCount() == 0) {
 			this->server_.removeChannel(left_ch_const.getName());
 		}
+	}
+}
+
+void Command::removeAllInvitedChannels(User &user) {
+	if (user.getInvitedChannelCount() == 0) {
+		return;
+	}
+	const std::vector<std::string> &invited_ch = user.getInvitedChannel();
+	for (std::vector<std::string>::const_iterator it = invited_ch.begin();
+		 it != invited_ch.end(); ++it) {
+		const std::string &ch_name = *it;
+		const Channel &ch = this->server_.getChannel(ch_name);
+		const_cast<Channel &>(ch).removeInvitedUser(user.getFd());
 	}
 }
 
@@ -37,6 +53,7 @@ void Command::QUIT(User &user, std::vector<std::string> &arg) {
 	} else {
 		broadcast_msg = " QUIT :" + extractAfterColon(1);
 	}
+	removeAllInvitedChannels(user);
 	quitAllChannels(user, broadcast_msg);
 	const int fd = user.getFd();
 	this->server_.removeUser(fd);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -155,6 +155,7 @@ std::string Server::recvCmdFromClient(const size_t i) {
 		Command cmd(*this);
 		User &user = user_map_[this->pollfd_vec_[i].fd];
 		const int fd = user.getFd();
+		cmd.removeAllInvitedChannels(user);
 		cmd.quitAllChannels(user,
 							"finish connection from " + user.getNickName());
 		close(fd);

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -55,7 +55,7 @@ const std::string &User::getRealName() const { return this->real_name_; }
 
 const std::string &User::getUserName() const { return this->user_name_; }
 
-const std::vector<std::string> &User::getInvitedChannel() const {
+const std::vector<std::string> &User::getInvitedChannels() const {
 	return this->invited_ch_;
 }
 

--- a/src/User.cpp
+++ b/src/User.cpp
@@ -12,6 +12,10 @@ User::AuthFlags User::getAuthFlags() const { return (this->auth_flag_); }
 
 size_t User::getJoinedChannelCount() const { return (this->ch_set_.size()); }
 
+size_t User::getInvitedChannelCount() const {
+	return (this->invited_ch_.size());
+}
+
 const std::set<std::string> &User::getJoinedChannels() const {
 	return (this->ch_set_);
 }
@@ -51,6 +55,10 @@ const std::string &User::getRealName() const { return this->real_name_; }
 
 const std::string &User::getUserName() const { return this->user_name_; }
 
+const std::vector<std::string> &User::getInvitedChannel() const {
+	return this->invited_ch_;
+}
+
 bool User::hasMode(const enum User::UserMode mode) const {
 	return (mode & this->mode_) != 0;
 }
@@ -71,6 +79,13 @@ void User::setUsername(const std::string &username) {
 	this->user_name_ = username;
 }
 
+void User::setInvitedChannel(const std::string &ch_name) {
+	std::cout << "start setInvitedChannel(): " << ch_name << std::endl;
+	this->invited_ch_.push_back(ch_name);
+	std::cout << "finish setInvitedChannel(): " << invited_ch_.size()
+			  << std::endl;
+}
+
 void User::setRealName(const std::string &real_name) {
 	this->real_name_ = real_name;
 }
@@ -79,4 +94,13 @@ bool User::isUsernameSet() const { return !this->user_name_.empty(); }
 
 void User::removeChannel(const std::string &ch_name) {
 	this->ch_set_.erase(ch_name);
+}
+
+void User::removeInvitedChannel(const std::string &ch_name) {
+	for (size_t i = 0; i < this->invited_ch_.size(); ++i) {
+		if (this->invited_ch_.at(i) == ch_name) {
+			this->invited_ch_.erase(this->invited_ch_.begin() + i);
+			return;
+		}
+	}
 }


### PR DESCRIPTION
[body]
- inviteされているユーザーがQUITやKILLで接続が切れた時にChannelクラスのinvited_user_メンバ変数に残ったままになってしまう問題を解決しました
- 招待されているチャンネルのvectorをUserクラスに持たせました


[notes]

close #159